### PR TITLE
Ask user for directories each time when exporting/importing

### DIFF
--- a/src/emulators/dolphin.py
+++ b/src/emulators/dolphin.py
@@ -135,32 +135,26 @@ class Dolphin:
         subprocess.run(args, capture_output=True, check=False)
         self.running = False
     
-    def export_dolphin_data(self, mode):
+    def export_dolphin_data(self, mode, directory_to_export_to):
         user_directory = self.settings.dolphin.user_directory
-        export_directory = self.settings.dolphin.export_directory
-        users_export_directory = os.path.join(export_directory, os.getlogin())
         
         if not os.path.exists(user_directory):
             messagebox.showerror("Missing Folder", "No dolphin data on local drive found")
             self.gui.configure_data_buttons(state="normal")
             return  # Handle the case when the user directory doesn't exist.
         if mode == "All Data":
-            copy_directory_with_progress(user_directory, users_export_directory, "Exporting All Dolphin Data", self.data_progress_frame)
-    def import_dolphin_data(self, mode):
+            copy_directory_with_progress(user_directory, directory_to_export_to, "Exporting All Dolphin Data", self.data_progress_frame)
+    def import_dolphin_data(self, mode, directory_to_import_from):
         user_directory = self.settings.dolphin.user_directory
-        export_directory = self.settings.dolphin.export_directory
-        users_export_directory = os.path.join(export_directory, os.getlogin())
         
-        if not os.path.exists(users_export_directory):
+        if not os.path.exists(directory_to_import_from):
             messagebox.showerror("Missing Folder", "No dolphin data associated with your username was found")
             return  # Handle the case when the user directory doesn't exist.
         if mode == "All Data":
-            copy_directory_with_progress(users_export_directory, user_directory, "Importing All Dolphin Data", self.data_progress_frame)
+            copy_directory_with_progress(directory_to_import_from, user_directory, "Importing All Dolphin Data", self.data_progress_frame)
     def delete_dolphin_data(self, mode):
         result = ""
         user_directory = self.settings.dolphin.user_directory
-        export_directory = self.settings.dolphin.export_directory
-        users_export_directory = os.path.join(export_directory, os.getlogin())
         
         def delete_directory(directory):
             if os.path.exists(directory):
@@ -174,8 +168,6 @@ class Dolphin:
             return False
         if mode == "All Data":
             result += f"Data Deleted from {user_directory}\n" if delete_directory(user_directory) else ""
-            result += f"Data deleted from {users_export_directory}\n" if delete_directory(users_export_directory) else ""
-            
         if result:
             messagebox.showinfo("Delete result", result)
         else:

--- a/src/emulators/yuzu.py
+++ b/src/emulators/yuzu.py
@@ -289,48 +289,41 @@ class Yuzu:
     
 
         
-    def export_yuzu_data(self, mode):
+    def export_yuzu_data(self, mode, directory_to_export_to):
         user_directory = self.settings.yuzu.user_directory
-        export_directory = self.settings.yuzu.export_directory
-        users_export_directory = os.path.join(export_directory, os.getlogin())
         
         if not os.path.exists(user_directory):
             messagebox.showerror("Missing Folder", "No yuzu data on local drive found")
             return  # Handle the case when the user directory doesn't exist.
 
         if mode == "All Data":
-            copy_directory_with_progress(user_directory, users_export_directory, "Exporting All Yuzu Data", self.data_progress_frame)
+            copy_directory_with_progress(user_directory, directory_to_export_to, "Exporting All Yuzu Data", self.data_progress_frame)
         elif mode == "Save Data":
             save_dir = os.path.join(user_directory, 'nand', 'user', 'save')
-            copy_directory_with_progress(save_dir, os.path.join(users_export_directory, 'nand', 'user', 'save'), "Exporting Yuzu Save Data", self.data_progress_frame)
+            copy_directory_with_progress(save_dir, os.path.join(directory_to_export_to, 'nand', 'user', 'save'), "Exporting Yuzu Save Data", self.data_progress_frame)
         elif mode == "Exclude 'nand' & 'keys'":
-            copy_directory_with_progress(user_directory, users_export_directory, "Exporting All Yuzu Data", self.data_progress_frame, ["nand", "keys"])
+            copy_directory_with_progress(user_directory, directory_to_export_to, "Exporting All Yuzu Data", self.data_progress_frame, ["nand", "keys"])
         else:
             messagebox.showerror("Error", f"An unexpected error has occured, {mode} is an invalid option.")
-    def import_yuzu_data(self, mode):
-        export_directory = self.settings.yuzu.export_directory
+    def import_yuzu_data(self, mode, directory_to_import_from):
         user_directory = self.settings.yuzu.user_directory
-        users_export_directory = os.path.join(export_directory, os.getlogin())
-        
-        if not os.path.exists(users_export_directory):
+        if not os.path.exists(directory_to_import_from):
             messagebox.showerror("Missing Folder", "No yuzu data associated with your username found")
             return
         if mode == "All Data":
-            copy_directory_with_progress(users_export_directory, user_directory, "Import All Yuzu Data", self.data_progress_frame)
+            copy_directory_with_progress(directory_to_import_from, user_directory, "Import All Yuzu Data", self.data_progress_frame)
         elif mode == "Save Data":
-            save_dir = os.path.join(users_export_directory, 'nand', 'user', 'save')
+            save_dir = os.path.join(directory_to_import_from, 'nand', 'user', 'save')
             copy_directory_with_progress(save_dir, os.path.join(user_directory, 'nand', 'user', 'save'), "Importing Yuzu Save Data", self.data_progress_frame)
         elif mode == "Exclude 'nand' & 'keys'":
-            copy_directory_with_progress(users_export_directory, user_directory, "Import All Yuzu Data", self.data_progress_frame, ["nand", "keys"])
+            copy_directory_with_progress(directory_to_import_from, user_directory, "Import All Yuzu Data", self.data_progress_frame, ["nand", "keys"])
         else:
             messagebox.showerror("Error", f"An unexpected error has occured, {mode} is an invalid option.")
     def delete_yuzu_data(self, mode):
         result = ""
 
         user_directory = self.settings.yuzu.user_directory
-        export_directory = self.settings.yuzu.export_directory
-        users_export_directory = os.path.join(export_directory, os.getlogin())
-        
+    
         def delete_directory(directory):
             if os.path.exists(directory):
                 try:
@@ -343,15 +336,12 @@ class Yuzu:
 
         if mode == "All Data":
             result += f"Data Deleted from {user_directory}\n" if delete_directory(user_directory) else ""
-            result += f"Data deleted from {users_export_directory}\n" if delete_directory(users_export_directory) else ""
         elif mode == "Save Data":
             save_dir = os.path.join(user_directory, 'nand', 'user', 'save')
             result += f"Data deleted from {save_dir}\n" if delete_directory(save_dir) else ""
-            result += f"Data deleted from {save_dir}\n" if delete_directory(save_dir) else ""
         elif mode == "Exclude 'nand' & 'keys'":
-            # Iterate through each of the 3 root folders and exclude 'nand' and 'keys' subfolder
             deleted = False
-            for root_folder in [user_directory, users_export_directory]:
+            for root_folder in user_directory:
                 if os.path.exists(root_folder) and os.listdir(root_folder):
                     subfolders_failed = []
                     for folder_name in os.listdir(root_folder):

--- a/src/gui/frames/dolphin/dolphin_frame.py
+++ b/src/gui/frames/dolphin/dolphin_frame.py
@@ -155,13 +155,29 @@ class DolphinFrame(EmulatorFrame):
         thread.start()
         Thread(target=self.enable_buttons_after_thread, args=(thread, ["main"], )).start()
     def import_data_button_event(self):
+        directory = PathDialog(title="Import Directory", text="Enter directory to import from: ", directory=True)
+        directory = directory.get_input()
+        if not all(directory):
+            if directory[1] is not None:
+                messagebox.showerror("Error", "The path you have provided is invalid")
+                return 
+            return
+        directory = directory[1]
         self.configure_data_buttons(state="disabled")
-        thread = Thread(target=self.dolphin.import_dolphin_data, args=(self.dolphin_import_optionmenu.get(),))
+        thread = Thread(target=self.dolphin.import_dolphin_data, args=(self.dolphin_import_optionmenu.get(), directory, ))
         thread.start()
         Thread(target=self.enable_buttons_after_thread, args=(thread, ["data"],)).start()
     def export_data_button_event(self):
+        directory = PathDialog(title="Export Directory", text="Enter directory to export to: ", directory=True)
+        directory = directory.get_input()
+        if not all(directory):
+            if directory[1] is not None:
+                messagebox.showerror("Error", "The path you have provided is invalid")
+                return 
+            return
+        directory = directory[1]
         self.configure_data_buttons(state="disabled")
-        thread = Thread(target=self.dolphin.export_dolphin_data, args=(self.dolphin_export_optionmenu.get(),))
+        thread = Thread(target=self.dolphin.export_dolphin_data, args=(self.dolphin_export_optionmenu.get(), directory, ))
         thread.start()
         Thread(target=self.enable_buttons_after_thread, args=(thread, ["data"],)).start()
     def delete_data_button_event(self):

--- a/src/gui/frames/settings/dolphin_settings_frame.py
+++ b/src/gui/frames/settings/dolphin_settings_frame.py
@@ -26,12 +26,6 @@ class DolphinSettingsFrame(customtkinter.CTkFrame):
         customtkinter.CTkButton(self, text="Browse", width=50, command=lambda entry_widget=self.install_directory_entry: self.update_with_explorer(entry_widget)).grid(row=2,column=3, padx=5, pady=5, sticky="E")
         ttk.Separator(self, orient='horizontal').grid(row=3, columnspan=4, sticky="ew")
 
-        customtkinter.CTkLabel(self, text="Export Directory: ").grid(row=6, column=0, padx=10, pady=10, sticky="w")
-        self.export_directory_entry = customtkinter.CTkEntry(self, width=300)
-        self.export_directory_entry.grid(row=6, column=2, padx=10, pady=10, sticky="e")
-        customtkinter.CTkButton(self, text="Browse", width=50, command=lambda entry_widget=self.export_directory_entry: self.update_with_explorer(entry_widget)).grid(row=6, column=3, padx=5, sticky="E")
-        ttk.Separator(self, orient='horizontal').grid(row=7, columnspan=4, sticky="ew")
-     
         customtkinter.CTkLabel(self, text="ROM Directory").grid(row=8, column=0, padx=10, pady=10, sticky="w")
         self.rom_directory_entry = customtkinter.CTkEntry(self, width=300)
         self.rom_directory_entry.grid(row=8,column=2,padx=10,pady=10,sticky="E" )
@@ -48,8 +42,6 @@ class DolphinSettingsFrame(customtkinter.CTkFrame):
             "user_directory": self.user_directory_entry,
     
             "install_directory":  self.install_directory_entry,
-        
-            "export_directory": self.export_directory_entry,
         
             "rom_directory": self.rom_directory_entry 
         

--- a/src/gui/frames/settings/yuzu_settings_frame.py
+++ b/src/gui/frames/settings/yuzu_settings_frame.py
@@ -25,12 +25,6 @@ class YuzuSettingsFrame(customtkinter.CTkFrame):
         self.install_directory_entry.grid(row=2, column=2, padx=10, pady=10, sticky="e")
         customtkinter.CTkButton(self, text="Browse", width=50, command=lambda entry_widget=self.install_directory_entry: self.update_with_explorer(entry_widget)).grid(row=2,column=3, padx=5, pady=5, sticky="E")
         ttk.Separator(self, orient='horizontal').grid(row=3, columnspan=4, sticky="ew")
-
-        customtkinter.CTkLabel(self, text="Export Directory: ").grid(row=6, column=0, padx=10, pady=10, sticky="w")
-        self.export_directory_entry = customtkinter.CTkEntry(self, width=300)
-        self.export_directory_entry.grid(row=6, column=2, padx=10, pady=10, sticky="e")
-        customtkinter.CTkButton(self, text="Browse", width=50, command=lambda entry_widget=self.export_directory_entry: self.update_with_explorer(entry_widget)).grid(row=6, column=3, padx=5, sticky="E")
-        ttk.Separator(self, orient='horizontal').grid(row=7, columnspan=4, sticky="ew")      
         
         customtkinter.CTkLabel(self, text="ROM Directory: ").grid(row=8, column=0, padx=10, pady=10, sticky="w")
         self.rom_directory_entry = customtkinter.CTkEntry(self, width=300)
@@ -53,7 +47,6 @@ class YuzuSettingsFrame(customtkinter.CTkFrame):
         self.matching_dict = {
             "user_directory": self.user_directory_entry,
             "install_directory": self.install_directory_entry,
-            "export_directory": self.export_directory_entry,
             "rom_directory": self.rom_directory_entry,
             "installer_path":  self.yuzu_installer_path_entry
         }

--- a/src/gui/frames/yuzu/yuzu_frame.py
+++ b/src/gui/frames/yuzu/yuzu_frame.py
@@ -376,13 +376,29 @@ class YuzuFrame(EmulatorFrame):
         thread.start()
         Thread(target=self.enable_buttons_after_thread, args=(thread, ["firmware_keys","mainline","early_access"],)).start()
     def import_data_button_event(self):
+        directory = PathDialog(title="Import Directory", text="Enter directory to import from: ", directory=True)
+        directory = directory.get_input()
+        if not all(directory):
+            if directory[1] is not None:
+                messagebox.showerror("Error", "The path you have provided is invalid")
+                return 
+            return
+        directory = directory[1]
         self.configure_data_buttons(state="disabled")
-        thread = Thread(target=self.yuzu.import_yuzu_data, args=(self.yuzu_import_optionmenu.get(),))
+        thread = Thread(target=self.yuzu.import_yuzu_data, args=(self.yuzu_import_optionmenu.get(),directory,))
         thread.start()
         Thread(target=self.enable_buttons_after_thread, args=(thread, ["data"],)).start()
     def export_data_button_event(self):
+        directory = PathDialog(title="Export Directory", text="Enter directory to export to: ", directory=True)
+        directory = directory.get_input()
+        if not all(directory):
+            if directory[1] is not None:
+                messagebox.showerror("Error", "The path you have provided is invalid")
+                return 
+            return
+        directory = directory[1]
         self.configure_data_buttons(state="disabled")
-        thread = Thread(target=self.yuzu.export_yuzu_data, args=(self.yuzu_export_optionmenu.get(),))
+        thread = Thread(target=self.yuzu.export_yuzu_data, args=(self.yuzu_export_optionmenu.get(), directory,))
         thread.start()
         Thread(target=self.enable_buttons_after_thread, args=(thread, ["data"],)).start()
     def delete_data_button_event(self):

--- a/src/gui/windows/path_dialog.py
+++ b/src/gui/windows/path_dialog.py
@@ -12,7 +12,8 @@ class PathDialog(CTkToplevel):
     """
 
     def __init__(self,
-                 filetypes,
+                 filetypes = None,
+                 directory = None,
                  fg_color: Optional[Union[str, Tuple[str, str]]] = None,
                  text_color: Optional[Union[str, Tuple[str, str]]] = None,
                  button_fg_color: Optional[Union[str, Tuple[str, str]]] = None,
@@ -36,6 +37,7 @@ class PathDialog(CTkToplevel):
         self._entry_border_color = ThemeManager.theme["CTkEntry"]["border_color"] if entry_border_color is None else self._check_color_type(entry_border_color)
         self._entry_text_color = ThemeManager.theme["CTkEntry"]["text_color"] if entry_text_color is None else self._check_color_type(entry_text_color)
 
+        self.directory_mode = directory
         self._user_input: Union[str, None] = None
         self._running: bool = False
         self._title = title
@@ -122,9 +124,13 @@ class PathDialog(CTkToplevel):
         self.after(150, lambda: self._entry.focus())  # set focus to entry with slight delay, otherwise, it won't work
         self._entry.bind("<Return>", self._ok_event)
     def _browse_event(self):
-        extensions= ["*" + ext[1:] for ext in self._filetypes]
+        
         self.withdraw()
-        path = filedialog.askopenfilename(filetypes=[("Custom file", extensions)])
+        if self.directory_mode:
+            path = filedialog.askdirectory()
+        else:
+            extensions= ["*" + ext[1:] for ext in self._filetypes]
+            path = filedialog.askopenfilename(filetypes=[("Custom file", extensions)])
         self.deiconify()
         self.lift()
         if path is None or path == "":
@@ -150,7 +156,7 @@ class PathDialog(CTkToplevel):
         self.master.wait_window(self)
         if self._user_input is None:
             return (False, None)
-        if os.path.exists(self._user_input) and os.path.splitext(self._user_input)[1].lower() in self._filetypes:
+        if os.path.exists(self._user_input) and ( (self._filetypes is not None and os.path.splitext(self._user_input)[1].lower() in self._filetypes) or (self._filetypes is None)):
             return (True, self._user_input)
         else:
             return (False, "Path does not exist or invalid filetype")

--- a/src/settings/dolphin_settings.py
+++ b/src/settings/dolphin_settings.py
@@ -9,7 +9,6 @@ class DolphinSettings:
         self.default_settings = {
             'user_directory': (os.path.join(os.getenv("APPDATA"), "Dolphin Emulator")),
             'install_directory': (os.path.join(os.getenv("LOCALAPPDATA"), "Dolphin Emulator")),
-            'export_directory': (os.path.join(os.getcwd(), "User Data","Dolphin")),
             'rom_directory': os.path.join(os.getcwd(), "ROMS", "Dolphin")
         }
         self._settings = self.default_settings.copy()
@@ -38,9 +37,7 @@ class DolphinSettings:
     
     install_directory = property(lambda self: self._get_property('install_directory'), 
                                  lambda self, value: self._set_directory_property('install_directory', value))
-    
-    export_directory = property(lambda self: self._get_property('export_directory'), 
-                                lambda self, value: self._set_directory_property('export_directory', value))
+
     rom_directory = property(lambda self: self._get_property('rom_directory'), 
                                 lambda self, value: self._set_directory_property('rom_directory', value))
     

--- a/src/settings/settings.py
+++ b/src/settings/settings.py
@@ -31,14 +31,12 @@ class Settings:
             "dolphin_settings": {
                 "user_directory": "",
                 "install_directory": "",
-                "export_directory": "",
                 "rom_directory": ""
                 
             },
             "yuzu_settings": {
                 "user_directory": "",
                 "install_directory": "",
-                "export_directory" : "",
                 "installer_path" : ""
                 
             },
@@ -142,7 +140,6 @@ class Settings:
             "dolphin_settings": {
                 "user_directory": self.dolphin.user_directory,
                 "install_directory": self.dolphin.install_directory,
-                "export_directory": self.dolphin.export_directory,
                 "rom_directory": self.dolphin.rom_directory
                 
             },

--- a/src/settings/yuzu_settings.py
+++ b/src/settings/yuzu_settings.py
@@ -9,12 +9,12 @@ class YuzuSettings:
         self.default_settings = {
             'user_directory': os.path.join(os.getenv("APPDATA"), "Yuzu"),
             'install_directory': os.path.join(os.getenv("LOCALAPPDATA"), "Yuzu"),
-            'export_directory': os.path.join(os.getcwd(), "User Data","Yuzu"),
             'installer_path': os.path.join(self.emulator_file_path, "yuzu_install.exe"),
             'rom_directory': os.path.join(os.getcwd(), "ROMS",)
         }
         self._settings = self.default_settings.copy()
         self.app_settings = master.app
+        self.refresh_app_settings = sum
     def restore_default(self):
         for name, value in self.default_settings.items():
             try:
@@ -59,8 +59,6 @@ class YuzuSettings:
     install_directory = property(lambda self: self._get_property('install_directory'), 
                                  lambda self, value: self._set_directory_property('install_directory', value))
     
-    export_directory = property(lambda self: self._get_property('export_directory'), 
-                                lambda self, value: self._set_directory_property('export_directory', value))
     rom_directory = property(lambda self: self._get_property('rom_directory'), 
                                 lambda self, value: self._set_directory_property('rom_directory', value))
     


### PR DESCRIPTION
When the user wants to import or export data, instead of using a setting, ask the user for the directory using PathDialog. 
Remove the settings in the apps 
Also means that exports aren't deleted anymore, don't know why they were being deleted in the first place