### PR TITLE
Use dolphin website

### DIFF
--- a/src/emulators/dolphin.py
+++ b/src/emulators/dolphin.py
@@ -140,35 +140,41 @@ class Dolphin:
         extracted = True
 
         
-        os.makedirs(self.settings.dolphin.install_directory, exist_ok=True)
-        with py7zr.SevenZipFile(release_archive, mode="r") as archive:
-            archive.extractall(path=self.settings.dolphin.install_directory)
-        parent_folder = self.settings.dolphin.install_directory
-        subfolder = os.path.join(self.settings.dolphin.install_directory, "Dolphin-x64")
-
-        contents = os.listdir(subfolder)
-
-
-        for item in contents:
-            item_path = os.path.join(subfolder, item)
-            destination_path = os.path.join(parent_folder, item)
-            shutil.move(item_path, destination_path)
-
-
-        os.rmdir(subfolder)
-        extracted_files = os.listdir(self.settings.dolphin.install_directory)
-        self.main_progress_frame.update_extraction_progress(1)
+        try:
             
-        self.main_progress_frame.grid_forget()
-        if extracted:
-            return (True, extracted_files)
-        else:
-            return (False, "Cancelled")
-        '''
+            if os.listdir(self.settings.dolphin.install_directory):
+                self.main_progress_frame.update_status_label("Deleting old installation...")
+                shutil.rmtree(self.settings.dolphin.install_directory)
+            os.makedirs(self.settings.dolphin.install_directory, exist_ok=True)
+            self.main_progress_frame.update_status_label("Extracting (Unable to show progress)...")
+            with py7zr.SevenZipFile(release_archive, mode="r") as archive:
+                archive.extractall(path=self.settings.dolphin.install_directory)
+            parent_folder = self.settings.dolphin.install_directory
+            subfolder = os.path.join(self.settings.dolphin.install_directory, "Dolphin-x64")
+
+            contents = os.listdir(subfolder)
+
+
+            for item in contents:
+                item_path = os.path.join(subfolder, item)
+                destination_path = os.path.join(parent_folder, item)
+                shutil.move(item_path, destination_path)
+
+
+            os.rmdir(subfolder)
+            extracted_files = os.listdir(self.settings.dolphin.install_directory)
+            self.main_progress_frame.update_extraction_progress(1)
+                
+            self.main_progress_frame.grid_forget()
+            if extracted:
+                return (True, extracted_files)
+            else:
+                return (False, "Cancelled")
+    
         except Exception as error:
             self.main_progress_frame.grid_forget()
             return (False, error)
-        '''
+
     def extract_zip_archive(self, release_archive):
         self.main_progress_frame.start_download(f"{os.path.basename(release_archive).replace(".zip", "")}", 0)
         self.main_progress_frame.complete_download()

--- a/src/emulators/dolphin.py
+++ b/src/emulators/dolphin.py
@@ -6,7 +6,7 @@ import time
 from tkinter import messagebox
 from zipfile import ZipFile
 
-import py7zr
+import py7zr 
 
 from gui.frames.progress_frame import ProgressFrame
 from utils.downloader import download_through_stream
@@ -143,11 +143,19 @@ class Dolphin:
         os.makedirs(self.settings.dolphin.install_directory, exist_ok=True)
         with py7zr.SevenZipFile(release_archive, mode="r") as archive:
             archive.extractall(path=self.settings.dolphin.install_directory)
-            extracted_files = archive.getnames()
-            archive.close()
-        shutil.move(os.path.join(self.settings.dolphin.install_directory, "Dolphin-x64"), self.settings.dolphin.install_directory)
+        parent_folder = self.settings.dolphin.install_directory
+        subfolder = os.path.join(self.settings.dolphin.install_directory, "Dolphin-x64")
 
-        
+        contents = os.listdir(subfolder)
+
+
+        for item in contents:
+            item_path = os.path.join(subfolder, item)
+            destination_path = os.path.join(parent_folder, item)
+            shutil.move(item_path, destination_path)
+
+
+        os.rmdir(subfolder)
         extracted_files = os.listdir(self.settings.dolphin.install_directory)
         self.main_progress_frame.update_extraction_progress(1)
             

--- a/src/emulators/dolphin.py
+++ b/src/emulators/dolphin.py
@@ -68,8 +68,7 @@ class Dolphin:
             return 
         extract_result = self.extract_release(release_archive)
         if path_to_archive is None and self.settings.app.delete_files == "True":
-            pass
-            #os.remove(release_archive)
+            os.remove(release_archive)
         if not all(extract_result):
             if extract_result[1]!="Cancelled":
                 messagebox.showerror("Extract Error", f"An error occurred while extracting the release: \n\n{extract_result[1]}")

--- a/src/emulators/dolphin.py
+++ b/src/emulators/dolphin.py
@@ -30,6 +30,8 @@ class Dolphin:
         os.remove(zip_path)
         
     def verify_dolphin_zip(self, path_to_archive):
+        if path_to_archive.endswith(".7z"): # don't know how else to check if its valid for 7z
+            return True 
         try:
             with ZipFile(path_to_archive, 'r') as archive:
                 if 'Dolphin.exe' in archive.namelist():
@@ -136,6 +138,7 @@ class Dolphin:
         self.main_progress_frame.start_download(os.path.basename(release_archive).replace(".7z",""), 0)
         self.main_progress_frame.complete_download()
         self.main_progress_frame.update_status_label("Extracting... ")
+        self.main_progress_frame.cancel_download_button.configure(state="disabled")
         self.main_progress_frame.grid(row=0, column=0, sticky="nsew")
         extracted = True
 

--- a/src/emulators/dolphin.py
+++ b/src/emulators/dolphin.py
@@ -1,15 +1,18 @@
 import os
+import re
 import shutil
 import subprocess
+import time
 from tkinter import messagebox
 from zipfile import ZipFile
 
-import requests
+import py7zr
 
 from gui.frames.progress_frame import ProgressFrame
 from utils.downloader import download_through_stream
 from utils.file_utils import copy_directory_with_progress
-from utils.requests_utils import get_headers, get_resources_release
+from utils.requests_utils import (create_get_connection,
+                                  get_file_links_from_page, get_headers)
 
 
 class Dolphin:
@@ -21,11 +24,8 @@ class Dolphin:
         self.dolphin_is_running = False
         self.main_progress_frame = None 
         self.data_progress_frame = None
-        self.dolphin_download_api = 'https://api.github.com/repos/Viren070/dolphin-beta-downloads/releases/latest'
-                    
-                
+                              
     def delete_dolphin_zip(self, zip_path):
-        import time 
         time.sleep(2)
         os.remove(zip_path)
         
@@ -38,28 +38,18 @@ class Dolphin:
                     return False
         except Exception:
             return False
-    def download_release(self, release):
-        download_folder = os.getcwd()
+   
         
-        
-        download_path = os.path.join(download_folder, f"Dolphin {release.version}.zip")
-        response = requests.get(release .download_url, stream=True, headers=get_headers(self.settings.app.token), timeout=30)
-        self.main_progress_frame.start_download(f"Dolphin {release.version}", release.size)
-        self.main_progress_frame.grid(row=0, column=0, sticky="ew")
- 
-        download_result = download_through_stream(response, download_path, self.main_progress_frame, 1024*203)
-        self.main_progress_frame.complete_download() 
-        return download_result
-        
-    def install_dolphin_handler(self, updating=False, path_to_archive=None):
+    def install_dolphin_handler(self, release_channel=None, path_to_archive=None, updating=False):
         release_archive = path_to_archive
+        if release_channel is None and path_to_archive is None:
+            raise ValueError("If release channel is None, you must provide a path to archive")
         if path_to_archive is None:
-            release_result = get_resources_release("Dolphin", headers=get_headers(self.settings.app.token))
+            release_result = self.get_dolphin_release(release_channel)
             if not all(release_result):
-                messagebox.showerror("Install Dolphin", f"There was an error while attempting to fetch the latest release of Dolphin:\n\n{release_result[1]}")
+                messagebox.showerror("Install Dolphin", f"There was an error while attempting to fetch the latest {release_channel} release of Dolphin:\n\n{release_result[1]}")
                 return 
             release = release_result[1]
-            release.version = release.name.replace("Dolphin.", "").replace(".zip", "")
             if release.version == self.metadata.get_installed_version("dolphin"):
                 if updating:
                     return 
@@ -76,7 +66,8 @@ class Dolphin:
             return 
         extract_result = self.extract_release(release_archive)
         if path_to_archive is None and self.settings.app.delete_files == "True":
-            os.remove(release_archive)
+            pass
+            #os.remove(release_archive)
         if not all(extract_result):
             if extract_result[1]!="Cancelled":
                 messagebox.showerror("Extract Error", f"An error occurred while extracting the release: \n\n{extract_result[1]}")
@@ -86,14 +77,98 @@ class Dolphin:
         messagebox.showinfo("Install Dolphin", f"Dolphin was successfully installed to {self.settings.dolphin.install_directory}")
         
    
+    def get_dolphin_release(self, release_channel):
+        files=get_file_links_from_page("https://dolphin-emu.org/download/", ".7z")
+        if not all(files):
+            return files 
+        files = files[1]
+        beta_build = None
+        dev_build = None
+        beta_build_number = None
+
+        for file in files:
+            if "ARM64" in file.filename:
+                continue
+
+            build_number = int(file.filename.split("-")[-2])
+            
+            if beta_build is None:
+                beta_build = file
+                beta_build_number = build_number
+                if release_channel == "beta":
+                    beta_build.version = re.search(r'(\d+\.\d+-\d+)', beta_build.filename).group(1)
+                    return (True, beta_build)
+            elif build_number > beta_build_number:
+                dev_build = file
+                dev_build.version = re.search(r'(\d+\.\d+-\d+)', dev_build.filename).group(1)
+                return (True, dev_build) 
+
+
+    def download_release(self, release):
+        download_folder = os.getcwd()
+        
+        
+        download_path = os.path.join(download_folder, f"{release.filename}.7z")
+        response_result = create_get_connection(release.url, headers=get_headers(), stream=True, timeout=30)
+        if not all(response_result):
+            return response_result
+        response = response_result[1]
+        release.size = int(response.headers.get('content-length', 0))
+        self.main_progress_frame.start_download(release.filename, release.size)
+        self.main_progress_frame.grid(row=0, column=0, sticky="ew")
+ 
+        download_result = download_through_stream(response, download_path, self.main_progress_frame, 1024*203)
+        self.main_progress_frame.complete_download() 
+        return download_result
+
     def extract_release(self, release): 
-        self.main_progress_frame.start_download(f"{os.path.basename(release).replace(".zip", "")}", 0)
+        if release.endswith(".zip"):
+            return self.extract_zip_archive(release)
+        elif release.endswith(".7z"):
+            return self.extract_7z_archive(release)
+        else:
+            raise Exception
+        
+        
+        
+    def extract_7z_archive(self, release_archive):
+    
+        self.main_progress_frame.start_download(os.path.basename(release_archive).replace(".7z",""), 0)
+        self.main_progress_frame.complete_download()
+        self.main_progress_frame.update_status_label("Extracting... ")
+        self.main_progress_frame.grid(row=0, column=0, sticky="nsew")
+        extracted = True
+
+        
+        os.makedirs(self.settings.dolphin.install_directory, exist_ok=True)
+        with py7zr.SevenZipFile(release_archive, mode="r") as archive:
+            archive.extractall(path=self.settings.dolphin.install_directory)
+            extracted_files = archive.getnames()
+            archive.close()
+        shutil.move(os.path.join(self.settings.dolphin.install_directory, "Dolphin-x64"), self.settings.dolphin.install_directory)
+
+        
+        extracted_files = os.listdir(self.settings.dolphin.install_directory)
+        self.main_progress_frame.update_extraction_progress(1)
+            
+        self.main_progress_frame.grid_forget()
+        if extracted:
+            return (True, extracted_files)
+        else:
+            return (False, "Cancelled")
+        '''
+        except Exception as error:
+            self.main_progress_frame.grid_forget()
+            return (False, error)
+        '''
+    def extract_zip_archive(self, release_archive):
+        self.main_progress_frame.start_download(f"{os.path.basename(release_archive).replace(".zip", "")}", 0)
         self.main_progress_frame.complete_download()
         self.main_progress_frame.update_status_label("Extracting... ")
         self.main_progress_frame.grid(row=0, column=0, sticky="nsew")
         extracted=True
         try:
-            with ZipFile(release, 'r') as archive:
+            with ZipFile(release_archive, 'r') as archive:
                 total_files = len(archive.namelist())
                 extracted_files = []
                 
@@ -111,6 +186,7 @@ class Dolphin:
             else:
                 return (False, "Cancelled")
         except Exception as error:
+            self.main_progress_frame.grid_forget()
             return (False, error)
    
     def delete_dolphin(self):
@@ -122,11 +198,11 @@ class Dolphin:
             return
        
         
-    def launch_dolphin_handler(self, skip_update=False):
+    def launch_dolphin_handler(self, release_channel, skip_update=False):
         if not skip_update:
 
             self.gui.configure_buttons("disabled", text="Fetching Updates...  ") 
-            self.install_dolphin_handler(True)
+            self.install_dolphin_handler(release_channel, None, True)
     
         self.gui.configure_buttons("disabled", text="Launched!  ") 
         dolphin_exe = os.path.join(self.settings.dolphin.install_directory, "Dolphin.exe")

--- a/src/gui/frames/dolphin/dolphin_frame.py
+++ b/src/gui/frames/dolphin/dolphin_frame.py
@@ -15,7 +15,8 @@ class DolphinFrame(EmulatorFrame):
     def __init__(self, parent_frame, settings, metadata):
         super().__init__(parent_frame, settings, metadata)
         self.dolphin = Dolphin(self, settings, metadata)
-        
+        self.dolphin_version = None 
+        self.installed_dolphin_version = None
         self.add_to_frame()
     def add_to_frame(self):
         self.dolphin_banner =  customtkinter.CTkImage(light_image=Image.open(self.settings.get_image_path("dolphin_banner_light")),
@@ -38,6 +39,11 @@ class DolphinFrame(EmulatorFrame):
         self.center_frame.grid_rowconfigure(1, weight=1)
         self.center_frame.grid_rowconfigure(2, weight=1)
         self.center_frame.grid_rowconfigure(3, weight=2)
+        
+        self.selected_channel = customtkinter.StringVar()
+        self.selected_channel.set(self.settings.dolphin.current_channel.title())
+        self.channel_optionmenu = customtkinter.CTkOptionMenu(self.center_frame, variable=self.selected_channel, command=self.switch_channel, values=["Beta", "Development"])
+        self.channel_optionmenu.grid(row=0, column=0, padx=10, pady=20, sticky="ne")
         
         self.image_button = customtkinter.CTkButton(self.center_frame, text="", fg_color='transparent', hover=False, bg_color='transparent', border_width=0, image=self.dolphin_banner)
         self.image_button.grid(row=0, column=0, columnspan=3, sticky="n", padx=10, pady=20)
@@ -106,6 +112,10 @@ class DolphinFrame(EmulatorFrame):
         self.rom_frame = DolphinROMFrame(self.manage_roms_frame, self.dolphin, self.settings)
         self.rom_frame.grid(row=0, column=0,  padx=20, pady=20, sticky="nsew")
     
+    def switch_channel(self, *args):
+        value = self.selected_channel.get()
+        self.settings.dolphin.current_channel = value.lower()
+        self.settings.update_file()
     def configure_data_buttons(self, **kwargs):
         self.dolphin_delete_button.configure(**kwargs)
         self.dolphin_import_button.configure(**kwargs)
@@ -124,7 +134,7 @@ class DolphinFrame(EmulatorFrame):
             return 
         self.configure_buttons("disabled", text="Launching...")
         shift_clicked = True if event.state & 1 else False
-        thread = Thread(target=self.dolphin.launch_dolphin_handler, args=(shift_clicked, ))
+        thread = Thread(target=self.dolphin.launch_dolphin_handler, args=(self.selected_channel.get().lower(), shift_clicked,))
         thread.start()
         Thread(target=self.enable_buttons_after_thread, args=(thread, ["main"])).start()
 
@@ -133,7 +143,7 @@ class DolphinFrame(EmulatorFrame):
             return 
         if os.path.exists(os.path.join(self.settings.dolphin.install_directory, "Dolphin.exe")) and not messagebox.askyesno("Confirmation", "Dolphin seems to already be installed, install anyways?"):
             return 
-        path_to_archive = None
+        
         if event.state & 1:
             path_to_archive = PathDialog(filetypes=(".zip",), title="Custom Dolphin Archive", text="Type path to Dolphin Archive: ")
             path_to_archive = path_to_archive.get_input()
@@ -142,8 +152,11 @@ class DolphinFrame(EmulatorFrame):
                     messagebox.showerror("Error", "The path you have provided is invalid")
                 return 
             path_to_archive = path_to_archive[1]
+            args = (None, path_to_archive, )
+        else:
+            args = (self.selected_channel.get().lower(), None)
         self.configure_buttons("disabled")
-        thread = Thread(target=self.dolphin.install_dolphin_handler, args=(False, path_to_archive, ))
+        thread = Thread(target=self.dolphin.install_dolphin_handler, args=args)
         thread.start()
         Thread(target=self.enable_buttons_after_thread, args=(thread, ["main"], )).start()
     def delete_dolphin_button_event(self):
@@ -197,7 +210,31 @@ class DolphinFrame(EmulatorFrame):
                 self.configure_buttons("normal", text="Launch Dolphin  ", width=170)
             elif button == "data":
                 self.configure_data_buttons(state="normal")
+        self.fetch_versions()
     
         
             
     
+    def fetch_versions(self, installed_only=True):
+        if not installed_only:
+            
+            dolphin_release = self.dolphin.get_dolphin_release(self.selected_channel.get().lower())
+            
+            if not all(dolphin_release):
+                return 
+            self.dolphin_version = dolphin_release[1].version
+            
+        self.installed_dolphin_version = self.metadata.get_installed_version("dolphin")
+      
+        self.update_version_text()
+        
+    def update_version_text(self):
+
+        if self.dolphin is not None and self.install_dolphin_button.cget("state") != "disabled":
+            self.install_dolphin_button.configure(text=f"Install Dolphin {self.dolphin_version}")
+        if self.installed_dolphin_version != "":
+            if self.launch_dolphin_button.cget("state") != "disabled":
+                self.launch_dolphin_button.configure(text=f"Launch Dolphin {self.installed_dolphin_version}  ")
+        else:
+            self.launch_dolphin_button.configure(text="Launch Dolphin  ")
+      

--- a/src/gui/frames/dolphin/dolphin_frame.py
+++ b/src/gui/frames/dolphin/dolphin_frame.py
@@ -145,7 +145,7 @@ class DolphinFrame(EmulatorFrame):
             return 
         
         if event.state & 1:
-            path_to_archive = PathDialog(filetypes=(".zip",), title="Custom Dolphin Archive", text="Type path to Dolphin Archive: ")
+            path_to_archive = PathDialog(filetypes=(".zip", ".7z", ), title="Custom Dolphin Archive", text="Type path to Dolphin Archive: ")
             path_to_archive = path_to_archive.get_input()
             if not all(path_to_archive):
                 if path_to_archive[1] is not None:

--- a/src/gui/frames/firmware_keys_frame.py
+++ b/src/gui/frames/firmware_keys_frame.py
@@ -5,7 +5,7 @@ import customtkinter
 
 from gui.CTkScrollableDropdown import CTkScrollableDropdown
 from gui.windows.path_dialog import PathDialog
-from utils.requests_utils import get_headers, get_all_releases
+from utils.requests_utils import get_all_releases, get_headers
 
 
 class FirmwareKeysFrame(customtkinter.CTkFrame):
@@ -55,7 +55,6 @@ class FirmwareKeysFrame(customtkinter.CTkFrame):
         
         
     def attempt_fetch(self, *args):
-        print(*args)
         if self.fetching_versions:
             messagebox.showwarning("Version Fetch", "A Fetch is already in progress, please try again later")
             return 

--- a/src/gui/frames/firmware_keys_frame.py
+++ b/src/gui/frames/firmware_keys_frame.py
@@ -1,0 +1,198 @@
+from threading import Thread
+from tkinter import messagebox
+
+import customtkinter
+
+from gui.CTkScrollableDropdown import CTkScrollableDropdown
+from gui.windows.path_dialog import PathDialog
+from utils.requests_utils import get_headers, get_all_releases
+
+
+class FirmwareKeysFrame(customtkinter.CTkFrame):
+    def __init__(self, master, gui):
+        super().__init__(master)
+        self.gui = gui
+        self.fetching_versions = False
+        self.build_frame()
+    def build_frame(self):
+      
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_columnconfigure(1, weight=1)
+
+
+        self.firmware_option_menu_variable = customtkinter.StringVar()
+        self.firmware_option_menu_variable.set("Fetching...")
+        self.key_option_menu_variable = customtkinter.StringVar()
+        self.key_option_menu_variable.set("Fetching...")
+        # Firmware Row
+        firmware_label = customtkinter.CTkLabel(self, text="Installed Firmware:")
+        firmware_label.grid(row=0, column=0, padx=10, pady=5, sticky="e")
+        self.installed_firmware_version_label = customtkinter.CTkLabel(self, text="Unknown")
+        self.installed_firmware_version_label.grid(row=0, column=1, padx=10, pady=5, sticky="w")
+
+        self.firmware_option_menu = customtkinter.CTkOptionMenu(self, state="disabled", variable=self.firmware_option_menu_variable, dynamic_resizing=False, width=200)
+        self.firmware_option_menu.grid(row=0, column=2, padx=10, pady=5, sticky="w")
+        self.firmware_option_menu.bind("<Button-1>", command=self.attempt_fetch)
+
+        self.install_firmware_button = customtkinter.CTkButton(self, text="Install", width=100, command=self.install_firmware_button_event)
+        self.install_firmware_button.bind("<Button-1>", command=self.install_firmware_button_event)
+        self.install_firmware_button.grid(row=0, column=3, padx=10, pady=5, sticky="w")
+
+        # Keys Row
+        keys_label = customtkinter.CTkLabel(self, text="Installed Keys:")
+        keys_label.grid(row=1, column=0, padx=10, pady=5, sticky="e")
+        self.installed_key_version_label = customtkinter.CTkLabel(self, text="Unknown")
+        self.installed_key_version_label.grid(row=1, column=1, padx=10, pady=5, sticky="w")
+
+        self.key_option_menu = customtkinter.CTkOptionMenu(self, width=200, state="disabled", dynamic_resizing=False, variable=self.key_option_menu_variable)
+        self.key_option_menu.grid(row=1, column=2, padx=10, pady=5, sticky="w")
+        self.key_option_menu.bind("<Button-1>", command=self.attempt_fetch)
+       
+
+        self.install_keys_button = customtkinter.CTkButton(self, text="Install", width=100, command=self.install_keys_button_event)
+        self.install_keys_button.bind("<Button-1>", command=self.install_keys_button_event)
+        self.install_keys_button.grid(row=1, column=3, padx=10, pady=5, sticky="w")
+        
+        
+    def attempt_fetch(self, *args):
+        print(*args)
+        if self.fetching_versions:
+            messagebox.showwarning("Version Fetch", "A Fetch is already in progress, please try again later")
+            return 
+        if not (self.firmware_option_menu_variable.get() == "Click to fetch versions" or self.key_option_menu_variable.get() == "Click to fetch versions"):
+            return 
+        self.fetching_versions = True 
+        Thread(target=self.fetch_firmware_and_key_versions, args=(True,)).start()
+    def configure_firmware_key_buttons(self, state):
+        self.install_firmware_button.configure(state=state)
+        self.install_keys_button.configure(state=state)
+        
+    def install_firmware_button_event(self, event=None):
+        if event is None or self.install_firmware_button.cget("state") == "disabled":
+            return
+        path_to_archive = None
+        if event.state & 1:
+            path_to_archive = PathDialog(filetypes=(".zip",), title="Custom Firmware Archive", text="Type path to Firmware Archive: ")
+            path_to_archive = path_to_archive.get_input()
+            if not all(path_to_archive):
+                if path_to_archive[1] is not None:
+                    messagebox.showerror("Error", "The path you have provided is invalid")
+                return 
+            path_to_archive = path_to_archive[1]
+            args = ("path", path_to_archive, )
+        else:
+            if self.firmware_option_menu.cget("state") == "disabled":
+                messagebox.showerror("Error", "Please ensure that a correct version has been chosen from the menu to the left")
+                return 
+            release = self.firmware_key_version_dict["firmware"][self.firmware_option_menu_variable.get()] 
+            args = ("release", release)
+        self.configure_firmware_key_buttons("disabled")
+        self.gui.configure_mainline_buttons("disabled")
+        self.gui.configure_early_access_buttons("disabled")
+        thread=Thread(target=self.gui.yuzu.install_firmware_handler, args=args)
+        thread.start()
+        Thread(target=self.gui.enable_buttons_after_thread, args=(thread, ["firmware_keys","mainline","early_access"], )).start()
+   
+    def install_keys_button_event(self, event=None):
+        if event is None or self.install_keys_button.cget("state") == "disabled":
+            return 
+        path_to_archive = None
+        if event.state & 1:
+            path_to_archive = PathDialog(filetypes=(".zip", ".keys"), title="Custom Key Archive", text="Type path to Key Archive: ")
+            path_to_archive = path_to_archive.get_input()
+            if not all(path_to_archive):
+                if path_to_archive[1] is not None:
+                    messagebox.showerror("Error", "The path you have provided is invalid")
+                return 
+            path_to_archive = path_to_archive[1]
+            args = ("path", path_to_archive, )
+        else:
+            if self.key_option_menu.cget("state") == "disabled":
+                messagebox.showerror("Error", "Please ensure that a correct version has been chosen from the menu to the left")
+                return 
+            release = self.firmware_key_version_dict["keys"][self.key_option_menu_variable.get()]  
+            args = ("release", release, )
+        self.gui.configure_firmware_key_buttons("disabled")
+        self.gui.configure_mainline_buttons("disabled")
+        self.gui.configure_early_access_buttons("disabled")  
+        
+        thread = Thread(target=self.gui.yuzu.install_key_handler, args=args)
+        thread.start()
+        Thread(target=self.gui.enable_buttons_after_thread, args=(thread, ["firmware_keys","mainline","early_access"],)).start()
+        
+    def fetch_firmware_and_key_versions(self, manual_fetch=False):
+        class Release:
+            def __init__(self):
+                self.name = None
+                self.download_url = None
+                self.size = None 
+                self.version = None
+        self.fetching_versions = True
+        self.firmware_key_version_dict = {
+            "firmware": {},
+            "keys": {}
+        }
+        self.firmware_option_menu_variable.set("Fetching...")
+        self.key_option_menu_variable.set("Fetching...")
+        releases = get_all_releases("https://api.github.com/repos/Viren070/Emulator-Manager-Resources/releases?per_page=100", get_headers(self.gui.settings.app.token))
+        if not all(releases):
+            self.firmware_option_menu_variable.set("Click to fetch versions")
+            self.key_option_menu_variable.set("Click to fetch versions")
+            self.fetching_versions = False
+            if manual_fetch:
+                messagebox.showerror("Fetch Error", f"There was an error while attempting to fetch the available versions for firmware and keys:\n\n {releases[1]}")
+            return 
+        releases = releases[1]
+        for release in releases:
+            if "-ns" not in release["tag_name"]:
+                continue 
+            if not release["assets"]:
+                continue 
+            version = release["name"]
+            assets = release["assets"]
+            
+            
+            key_release = None
+            firmware_release = None
+            
+            for asset in assets:
+                if "Alpha" in asset["name"]:
+                    firmware_release = Release()
+                    firmware_release.name = asset["name"].replace("Alpha","Firmware")
+                    firmware_release.download_url = asset["browser_download_url"]
+                    firmware_release.size = asset["size"]
+                    firmware_release.version = version 
+                elif "Rebootless" not in version and "Beta" in asset["name"]:
+                    key_release = Release()
+                    key_release.name = asset["name"].replace("Beta", "Keys")
+                    key_release.download_url = asset["browser_download_url"]
+                    key_release.size = asset["size"]
+                    key_release.version = version
+            
+            if firmware_release is not None:
+                self.firmware_key_version_dict["firmware"][version] = firmware_release
+            if key_release is not None and "Rebootless" not in version:
+                self.firmware_key_version_dict["keys"][version] = key_release
+            
+        # Extract firmware versions from the self.firmware_key_version_dict
+        firmware_versions = [release.version for release in self.firmware_key_version_dict.get("firmware", {}).values()]
+
+        # Extract key versions from the self.firmware_key_version_dict
+        key_versions = [release.version for release in self.firmware_key_version_dict.get("keys", {}).values()]
+
+        if not len(key_versions) == 0:
+            self.key_option_menu_variable.set(key_versions[0])
+            self.key_option_menu.configure(state="normal")
+        else:
+            self.key_option_menu_variable.set("None Found")
+        if not len(firmware_versions) == 0:
+            self.firmware_option_menu_variable.set(firmware_versions[0])
+            self.firmware_option_menu.configure(state="normal")
+        else:
+            self.firmware_option_menu_variable.set("None Found")
+        
+        self.install_firmware_button.configure(state="normal")
+        self.install_keys_button.configure(state="normal")
+        CTkScrollableDropdown(self.firmware_option_menu, width=300, height=200, values=firmware_versions, resize=False, button_height=30)
+        CTkScrollableDropdown(self.key_option_menu, width=300, height=200, values=key_versions, resize=False, button_height=30)
+        self.fetching_versions = False

--- a/src/gui/frames/settings/app_settings_frame.py
+++ b/src/gui/frames/settings/app_settings_frame.py
@@ -30,7 +30,7 @@ class AppSettingsFrame(customtkinter.CTkFrame):
         self.appearance_mode_variable = customtkinter.StringVar()
         self.colour_theme_variable = customtkinter.StringVar()
         self.use_yuzu_installer_variable = customtkinter.StringVar()
-        self.use_yuzu_installer_variable.set(self.settings.app.use_yuzu_installer)
+        self.use_yuzu_installer_variable.set(self.settings.yuzu.use_yuzu_installer)
         self.appearance_mode_variable.set(self._get_appearance_mode().title())
         self.colour_theme_variable.set(os.path.basename(customtkinter.ThemeManager._currently_loaded_theme).replace("-"," ").replace(".json", "").title())
         self.delete_files_variable = customtkinter.StringVar()

--- a/src/gui/frames/yuzu/yuzu_frame.py
+++ b/src/gui/frames/yuzu/yuzu_frame.py
@@ -142,7 +142,7 @@ class YuzuFrame(EmulatorFrame):
         
         self.early_access_actions_frame.grid_propagate(False)
         self.mainline_actions_frame.grid_propagate(False)
-        self.selected_channel.set(self.settings.app.current_yuzu_channel)
+        self.selected_channel.set(self.settings.yuzu.current_yuzu_channel)
         self.switch_channel()
         
         self.manage_roms_frame = customtkinter.CTkFrame(self, corner_radius = 0, bg_color = "transparent")
@@ -166,7 +166,7 @@ class YuzuFrame(EmulatorFrame):
         
     def switch_channel(self, value=None):
         value=self.selected_channel.get()
-        self.settings.app.current_yuzu_channel = value
+        self.settings.yuzu.current_yuzu_channel = value
         self.settings.update_file()
         if value == "Mainline":
             self.image_button.configure(image=self.mainline_image)
@@ -322,8 +322,7 @@ class YuzuFrame(EmulatorFrame):
                 self.firmware_keys_frame.configure_firmware_key_buttons("normal")
             elif button == "data":
                 self.configure_data_buttons(state="normal")
-        Thread(target=self.fetch_versions).start()
-        self.update_version_text()
+        self.fetch_versions()
     def fetch_versions(self, installed_only=True):
         if not installed_only:
             self.firmware_keys_frame.fetch_firmware_and_key_versions()

--- a/src/gui/frames/yuzu/yuzu_frame.py
+++ b/src/gui/frames/yuzu/yuzu_frame.py
@@ -6,14 +6,12 @@ import customtkinter
 from CTkToolTip import CTkToolTip
 from PIL import Image
 
-from gui.CTkScrollableDropdown import CTkScrollableDropdown
 from emulators.yuzu import Yuzu
 from gui.frames.emulator_frame import EmulatorFrame
-from gui.frames.progress_frame import ProgressFrame
 from gui.frames.firmware_keys_frame import FirmwareKeysFrame
+from gui.frames.progress_frame import ProgressFrame
 from gui.frames.yuzu.yuzu_rom_frame import YuzuROMFrame
 from gui.windows.path_dialog import PathDialog
-from utils.requests_utils import get_headers, get_all_releases
 
 
 class YuzuFrame(EmulatorFrame):

--- a/src/gui/frames/yuzu/yuzu_frame.py
+++ b/src/gui/frames/yuzu/yuzu_frame.py
@@ -186,12 +186,6 @@ class YuzuFrame(EmulatorFrame):
         self.manage_roms_frame.grid_rowconfigure(0, weight=1)
         self.rom_frame = YuzuROMFrame(self.manage_roms_frame, self.yuzu, self.settings)
         self.rom_frame.grid(row=0, column=0,  padx=20, pady=20, sticky="nsew")
-    
-        Thread(target=self.fetch_versions, args=(False,)).start()
-        
-
-    
-        
  
     def configure_data_buttons(self, **kwargs):
         self.yuzu_delete_button.configure(**kwargs)

--- a/src/gui/windows/emulator_manager.py
+++ b/src/gui/windows/emulator_manager.py
@@ -41,6 +41,7 @@ class EmulatorManager(customtkinter.CTk):
             
         self.protocol("WM_DELETE_WINDOW", self.on_closing)
         Thread(target=self.yuzu_frame.fetch_versions, args=(False,)).start()
+        Thread(target=self.dolphin_frame.fetch_versions, args=(False,)).start()
         self.mainloop()
     def define_images(self):
         self.dolphin_logo = customtkinter.CTkImage(Image.open(self.settings.get_image_path("dolphin_logo")), size=(26, 26))

--- a/src/gui/windows/emulator_manager.py
+++ b/src/gui/windows/emulator_manager.py
@@ -2,6 +2,7 @@ import os
 import shutil
 from sys import exit as sysexit
 from tkinter import messagebox
+from threading import Thread 
 
 import customtkinter
 from PIL import Image
@@ -39,6 +40,7 @@ class EmulatorManager(customtkinter.CTk):
             self.settings_frame.select_settings_frame_by_name("app")
             
         self.protocol("WM_DELETE_WINDOW", self.on_closing)
+        Thread(target=self.yuzu_frame.fetch_versions, args=(False,)).start()
         self.mainloop()
     def define_images(self):
         self.dolphin_logo = customtkinter.CTkImage(Image.open(self.settings.get_image_path("dolphin_logo")), size=(26, 26))

--- a/src/settings/app_settings.py
+++ b/src/settings/app_settings.py
@@ -13,7 +13,6 @@ class AppSettings:
         self.default_settings = {
             'colour_theme': "dark-blue",
             'appearance_mode': "dark",
-            'current_yuzu_channel': 'Mainline',
             'delete_files': 'True', 
             'ask_firmware': 'True',
             'token': ''
@@ -37,9 +36,6 @@ class AppSettings:
     
     appearance_mode = property(lambda self: self._get_property('appearance_mode'), 
                                  lambda self, value: self._set_property('appearance_mode', value))
-   
-    current_yuzu_channel = property(lambda self: self._get_property('current_yuzu_channel'), 
-                                     lambda self, value: self._set_property('current_yuzu_channel', value))
     delete_files = property(lambda self: self._get_property('delete_files'), 
                                      lambda self, value: self._set_property('delete_files', value))
     ask_firmware = property(lambda self: self._get_property('ask_firmware'), 

--- a/src/settings/dolphin_settings.py
+++ b/src/settings/dolphin_settings.py
@@ -9,7 +9,8 @@ class DolphinSettings:
         self.default_settings = {
             'user_directory': (os.path.join(os.getenv("APPDATA"), "Dolphin Emulator")),
             'install_directory': (os.path.join(os.getenv("LOCALAPPDATA"), "Dolphin Emulator")),
-            'rom_directory': os.path.join(os.getcwd(), "ROMS", "Dolphin")
+            'rom_directory': os.path.join(os.getcwd(), "ROMS", "Dolphin"),
+            'current_channel': "beta"
         }
         self._settings = self.default_settings.copy()
 
@@ -29,6 +30,9 @@ class DolphinSettings:
         else:
             raise ValueError(f"{property_name.replace('__','/').replace('_',' ').title()} - Invalid Path: {(value)}")
    
+    def _set_property(self, property_name, value):
+        self._settings[property_name] = value
+        
     def _get_property(self, property_name):
         return self._settings[property_name]
     
@@ -40,5 +44,6 @@ class DolphinSettings:
 
     rom_directory = property(lambda self: self._get_property('rom_directory'), 
                                 lambda self, value: self._set_directory_property('rom_directory', value))
-    
+    current_channel = property(lambda self: self._get_property('current_channel'), 
+                                lambda self, value: self._set_property('current_channel', value))
    

--- a/src/settings/settings.py
+++ b/src/settings/settings.py
@@ -31,7 +31,8 @@ class Settings:
             "dolphin_settings": {
                 "user_directory": "",
                 "install_directory": "",
-                "rom_directory": ""
+                "rom_directory": "",
+                "current_channel": ""
                 
             },
             "yuzu_settings": {
@@ -39,6 +40,7 @@ class Settings:
                 "install_directory": "",
                 "installer_path" : "",
                 "use_yuzu_installer": "",
+                "current_yuzu_channel": "",
                 "rom_directory": ""
                 
             },
@@ -60,7 +62,6 @@ class Settings:
                 "appearance_mode" : "",
                 "colour_theme" : "",
                 "delete_files": "",
-                "current_yuzu_channel": "",
                 "ask_firmware": ""
             }
         }
@@ -139,7 +140,8 @@ class Settings:
             "dolphin_settings": {
                 "user_directory": self.dolphin.user_directory,
                 "install_directory": self.dolphin.install_directory,
-                "rom_directory": self.dolphin.rom_directory
+                "rom_directory": self.dolphin.rom_directory,
+                "current_channel": self.dolphin.current_channel
                 
             },
             "yuzu_settings": {
@@ -148,6 +150,7 @@ class Settings:
                 "rom_directory" : self.yuzu.rom_directory,
                 "installer_path" : self.yuzu.installer_path,
                 "use_yuzu_installer":  self.yuzu.use_yuzu_installer,
+                "current_yuzu_channel": self.yuzu.current_yuzu_channel
                 
             },
             "app_settings": {
@@ -155,7 +158,6 @@ class Settings:
                 "appearance_mode" : self.app.appearance_mode,
                 "colour_theme" : self.app.colour_theme,
                 "delete_files" : self.app.delete_files,
-                "current_yuzu_channel": self.app.current_yuzu_channel,
                 "ask_firmware": self.app.ask_firmware
             }
         }

--- a/src/settings/yuzu_settings.py
+++ b/src/settings/yuzu_settings.py
@@ -11,11 +11,11 @@ class YuzuSettings:
             'install_directory': os.path.join(os.getenv("LOCALAPPDATA"), "Yuzu"),
             'installer_path': "",
             'use_yuzu_installer': 'False',
+            'current_yuzu_channel': "Mainline",
             'rom_directory': os.path.join(os.getcwd(), "ROMS",)
             
         }
         self._settings = self.default_settings.copy()
-        self.app_settings = master.app
         self.refresh_app_settings = sum
     def restore_default(self):
         for name, value in self.default_settings.items():
@@ -39,18 +39,18 @@ class YuzuSettings:
     def _set_path_property(self, property_name, value):
         if value == "" or value==".":
             self._settings[property_name] = value
-            self.app_settings.use_yuzu_installer = "False"
+            self.use_yuzu_installer = "False"
             self.refresh_app_settings()
             return
         if not os.path.exists(value):
             if not os.path.exists(self.default_settings[property_name]):
                 self._settings[property_name] = ""
-            self.app_settings.use_yuzu_installer = "False"
+            self.use_yuzu_installer = "False"
             self.refresh_app_settings()
             raise FileNotFoundError(f"{property_name.replace('__','/').replace('_',' ').title()} - Path does not exist: {value}")
         
         if property_name == "installer_path" and not value.endswith(".exe"):
-            self.app_settings.use_yuzu_installer = "False"
+            self.use_yuzu_installer = "False"
             self.refresh_app_settings()
             raise ValueError(f"{property_name.replace('__','/').replace('_',' ').title()} - Invalid Filetype: Expected file extension of .exe but got {os.path.splitext(value)[-1]}")
                           
@@ -73,3 +73,7 @@ class YuzuSettings:
     
     use_yuzu_installer = property(lambda self: self._get_property('use_yuzu_installer'), 
                                      lambda self, value: self._set_property('use_yuzu_installer', value))
+    
+    current_yuzu_channel = property(lambda self: self._get_property('current_yuzu_channel'), 
+                                     lambda self, value: self._set_property('current_yuzu_channel', value))
+    

--- a/src/utils/requests_utils.py
+++ b/src/utils/requests_utils.py
@@ -91,7 +91,9 @@ def get_resources_release(file, headers=None):
     release = get_release_from_assets(assets, query)
     return (True, release)
     
-def get_file_links_from_page(url, file_ext=None, headers=DEFAULT_HEADER):
+def get_file_links_from_page(url, file_ext=None, headers=None):
+    if headers is None:
+        headers = DEFAULT_HEADER
 
     response_result = create_get_connection(url, headers=headers, timeout=30)
     if not all(response_result):

--- a/src/utils/requests_utils.py
+++ b/src/utils/requests_utils.py
@@ -91,7 +91,7 @@ def get_resources_release(file, headers=None):
     release = get_release_from_assets(assets, query)
     return (True, release)
     
-def get_file_links_from_page(url, file_ext=None, headers=None):
+def get_file_links_from_page(url, file_ext, headers=None):
     if headers is None:
         headers = DEFAULT_HEADER
 
@@ -105,7 +105,7 @@ def get_file_links_from_page(url, file_ext=None, headers=None):
     for link in links:
         href = link.get('href')
         if (file_ext is None) or (href.endswith(file_ext) and href not in [file.url for file in files]):
-            filename=re.sub('<[^>]+>', '', str(link)).replace("&amp;", "&")
+            filename=link['href'].split('/')[-1].split(file_ext)[-2] 
             result=urlparse(href)
             if all([result.scheme, result.netloc]):
                 file_url = href
@@ -116,5 +116,3 @@ def get_file_links_from_page(url, file_ext=None, headers=None):
                     continue
             files.append(File(file_url, filename))
     return (True, files)
-    
-            


### PR DESCRIPTION
This PR focuses on using the official dolphin website to download releases of dolphin. It adds a option menu to the dolphin menu where you can switch between beta and development. 
 - The main menu for dolphin has a dropdown menu to switch between beta and development releases 
 - The last release channel the user was on is stored and that release channel is switched to upon opening the app 
 - Versions are now displayed on the launch and install buttons for dolphin 
 - 7z archives are now supported for dolphin installs
     -  the progress bar isn't updated as all files are extracted at once. This is because if I tried to extract each file individually, it would take seconds for a single folder. This would take too long and after trying several different libraries, I found nothing and settled for the current case, 