### PR TITLE
Use cache system where possible 

### DIFF
--- a/src/gui/frames/dolphin/dolphin_frame.py
+++ b/src/gui/frames/dolphin/dolphin_frame.py
@@ -15,9 +15,10 @@ from gui.frames.emulator_frame import EmulatorFrame
 
 DOLPHIN_FOLDERS = ["Backup", "Cache", "Config", "Dump", "GameSettings", "GBA", "GC", "Load", "Logs", "Maps", "ResourcePacks", "SavedAssembly", "ScreenShots", "Shaders", "StateSaves", "Styles", "Themes", "Wii"]
 class DolphinFrame(EmulatorFrame):
-    def __init__(self, parent_frame, settings, metadata):
+    def __init__(self, parent_frame, settings, metadata, cache):
         super().__init__(parent_frame, settings, metadata)
         self.dolphin = Dolphin(self, settings, metadata)
+        self.cache = cache
         self.dolphin_version = None
         self.installed_dolphin_version = None
         self.add_to_frame()
@@ -109,7 +110,7 @@ class DolphinFrame(EmulatorFrame):
 
         self.manage_roms_frame = customtkinter.CTkFrame(self, corner_radius=0, bg_color="transparent")
 
-        self.rom_frame = DolphinROMFrame(self.manage_roms_frame, self.dolphin, self.settings)
+        self.rom_frame = DolphinROMFrame(self.manage_roms_frame, self.dolphin, self.settings, self.cache)
         self.rom_frame.grid(row=0, column=0,  padx=20, pady=20, sticky="nsew")
 
     def switch_channel(self, *args):

--- a/src/gui/frames/dolphin/dolphin_rom_frame.py
+++ b/src/gui/frames/dolphin/dolphin_rom_frame.py
@@ -13,10 +13,11 @@ from utils.requests_utils import create_get_connection, get_headers
 
 
 class DolphinROMFrame(customtkinter.CTkTabview):
-    def __init__(self, master, dolphin, settings):
+    def __init__(self, master, dolphin, settings, cache):
         super().__init__(master, height=500, width=700)
         self.master = master
         self.roms = None
+        self.cache = cache
         self.settings = settings
         self.dolphin = dolphin
         self.results_per_page = 10
@@ -39,9 +40,9 @@ class DolphinROMFrame(customtkinter.CTkTabview):
 
         self.current_roms_frame = CurrentROMSFrame(self.tab("My ROMs"), self, self.settings.dolphin,  (".wbfs", ".iso", ".rvz", ".gcm", ".gcz", ".ciso"))
         self.current_roms_frame.grid(row=0, column=0, padx=5, pady=5, sticky="nsew")
-        self.wii_roms_frame = ROMSearchFrame(self.tab("Wii ROMs"), self, "https://myrient.erista.me/files/Redump/Nintendo%20-%20Wii%20-%20NKit%20RVZ%20[zstd-19-128k]/",)
+        self.wii_roms_frame = ROMSearchFrame(self.tab("Wii ROMs"), self, "https://myrient.erista.me/files/Redump/Nintendo%20-%20Wii%20-%20NKit%20RVZ%20[zstd-19-128k]",)
         self.wii_roms_frame.grid(row=0, column=0, padx=5, pady=5, sticky="nsew")
-        self.gamecube_roms_frame = ROMSearchFrame(self.tab("GameCube ROMs"), self, "https://myrient.erista.me/files/Redump/Nintendo%20-%20GameCube%20-%20NKit%20RVZ%20[zstd-19-128k]/")
+        self.gamecube_roms_frame = ROMSearchFrame(self.tab("GameCube ROMs"), self, "https://myrient.erista.me/files/Redump/Nintendo%20-%20GameCube%20-%20NKit%20RVZ%20[zstd-19-128k]")
         self.gamecube_roms_frame.grid(row=0, column=0, padx=5, pady=5, sticky="nsew")
         self.downloads_frame = customtkinter.CTkScrollableFrame(self.tab("Downloads"), width=650, height=420)
         self.downloads_frame.grid_columnconfigure(0, weight=1)

--- a/src/gui/windows/emulator_manager.py
+++ b/src/gui/windows/emulator_manager.py
@@ -123,7 +123,7 @@ class EmulatorManager(customtkinter.CTk):
         self.settings_button.grid(row=2, column=0, sticky="ew")
 
         self.yuzu_frame = YuzuFrame(self, self.settings, self.metadata, self.cache)
-        self.dolphin_frame = DolphinFrame(self, self.settings, self.metadata)
+        self.dolphin_frame = DolphinFrame(self, self.settings, self.metadata, self.cache)
         self.ryujinx_frame = RyujinxFrame(self, self.settings, self.metadata, self.cache)
         self.settings_frame = SettingsFrame(self, self.settings)
 

--- a/src/utils/requests_utils.py
+++ b/src/utils/requests_utils.py
@@ -10,11 +10,11 @@ DEFAULT_HEADER = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Apple
 
 
 class Release:
-    def __init__(self) -> None:
-        self.name = None
-        self.download_url = None
-        self.size = None
-        self.version = None
+    def __init__(self, name=None, download_url=None, size=None, version=None) -> None:
+        self.name = name
+        self.download_url = download_url
+        self.size = size
+        self.version = version
 
 
 class File:


### PR DESCRIPTION
Updated the code to use the new cache system for other parts of the code. 

* The ROMSearchFrame will use the cache to store the links of all ROMs and display them at launch instead of waiting for user input and sending a nework request to myrient. The links will be used regardless of the age of the cached data. 
* A adapted dictionary storing the firmware and key versions and other metadata is stored in the cache in the FirmwareKeysFrame. This means that the dropdown will be available upon launching the app and the user does not have to click to fetch versions. The links in cache will only be used if they are less than 7 days old.